### PR TITLE
Add url callback option to google oauth2

### DIFF
--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -21,7 +21,13 @@
 
 	async function googleOAuthSignIn() {
 		try {
-			await pb.collection('users').authWithOAuth2({ provider: 'google' });
+			let w = window.open() as Window;
+			await pb.collection('users').authWithOAuth2({
+				provider: 'google',
+				urlCallback: (url) => {
+					w.location.href = url;
+				}
+			});
 			goto('/');
 		} catch (err) {
 			console.error(err);


### PR DESCRIPTION
This should allow IOS Oauth2 to work properly. Previously, Google Oauth2 login would not work on IOS because the popup to login would not appear. The solution was taken from this discussion https://github.com/pocketbase/pocketbase/discussions/2429